### PR TITLE
chore: pass Dependabot alerts token

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,7 +14,8 @@ permissions:
 
 jobs:
   cicd:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 'main' || startsWith(github.ref_name, 'releases/') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.ref_name == 
+      'main' || startsWith(github.ref_name, 'releases/') }}
     uses: simplify9/.github/.github/workflows/reusable-service-cicd.yml@main
     with:
       major-version: '6'
@@ -31,7 +32,7 @@ jobs:
 
       chart-name: 'mtm'                     # must match charts/default Chart.yaml name:
       chart-path: './charts/default'
-      chart-repo-url: https://charts.sf9.io 
+      chart-repo-url: https://charts.sf9.io
 
       # 1) Publish the Helm chart to GHCR OCI only (as the old pipeline did)
       chart-publish-method: 'both'
@@ -82,3 +83,4 @@ jobs:
 
       # App configuration passed to helm --set-string during deploy (masked)
       helm-set-secret-values: 'db=${{ secrets.DBCS }}'
+      dependabot-alerts-token: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}}}


### PR DESCRIPTION
Adds the following named secret to reusable-workflow calls on `main`:

```yaml
secrets:
  dependabot-alerts-token: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}
```

Existing secret mappings are preserved. The new entry is appended after existing entries.

Jobs using `secrets: inherit` are intentionally unchanged because inherited secrets cannot be combined with an explicit mapping.

The `.github` repository is excluded from this migration.